### PR TITLE
Allow on-prem use

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,9 @@ gcc_url: "{{ gcc_mirror_url }}/gcc-{{ GCCVER }}/gcc-{{ GCCVER }}.tar.gz"
 binutils_file: "binutils-{{ binutilsver }}.tar.bz2"
 binutils_url: "http://ftp.gnu.org/gnu/binutils/{{ binutils_file }}"
 prefix: /usr/local
-dejagnu_url: "https://ftp.nluug.nl/pub/gnu/dejagnu/dejagnu-1.6.3.tar.gz"
+gnu_mirror: 'https://ftp.nluug.nl/pub/gnu/'
+
+# for building
 dependencies_url: 'https://gcc.gnu.org/pub/gcc/infrastructure/'
 dependencies_url_signed: true
 dependencies:
@@ -31,3 +33,8 @@ dependencies:
     dir: 'mpfr-3.1.6'
     file: 'mpfr-3.1.6.tar.bz2'
     md5: 320c28198def956aeacdb240b46b8969
+
+# for testing
+test_gcc: false
+dejagnu_ver: 1.6.3
+dejagnu_url: "{{ gnu_mirror }}/dejagnu/dejagnu-{{ dejagnu_ver }}.tar.gz"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ gcc_url: "{{ gcc_mirror_url }}/gcc-{{ GCCVER }}/gcc-{{ GCCVER }}.tar.gz"
 binutils_file: "binutils-{{ binutilsver }}.tar.bz2"
 binutils_url: "http://ftp.gnu.org/gnu/binutils/{{ binutils_file }}"
 prefix: /usr/local
-
+dejagnu_url: "https://ftp.nluug.nl/pub/gnu/dejagnu/dejagnu-1.6.3.tar.gz"
 dependencies_url: 'https://gcc.gnu.org/pub/gcc/infrastructure/'
 dependencies_url_signed: true
 dependencies:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,28 @@ GCCVER: '10.3.0'
 
 gcc_configure: '--disable-multilib --enable-languages=c,c++'
 gcc_mirror_url: 'http://mirrors.concertpass.com/gcc/releases'
+gcc_mirror_url_signed: false
 gcc_url: "{{ gcc_mirror_url }}/gcc-{{ GCCVER }}/gcc-{{ GCCVER }}.tar.gz"
 binutils_file: "binutils-{{ binutilsver }}.tar.bz2"
 binutils_url: "http://ftp.gnu.org/gnu/binutils/{{ binutils_file }}"
 prefix: /usr/local
+
+dependencies_url: 'https://gcc.gnu.org/pub/gcc/infrastructure/'
+dependencies_url_signed: true
+dependencies:
+  - name: gmp
+    dir: 'gmp-6.1.0'
+    file: 'gmp-6.1.0.tar.bz2'
+    md5: 86ee6e54ebfc4a90b643a65e402c4048
+  - name: isl
+    dir: 'isl-0.18'
+    file: 'isl-0.18.tar.bz2'
+    md5: 11436d6b205e516635b666090b94ab32
+  - name: mpc
+    dir: 'mpc-1.0.3'
+    file: 'mpc-1.0.3.tar.gz'
+    md5: d6a1d5f8ddea3abd2cc3e98f58352d26
+  - name: mpfr
+    dir: 'mpfr-3.1.6'
+    file: 'mpfr-3.1.6.tar.bz2'
+    md5: 320c28198def956aeacdb240b46b8969

--- a/files/config_make_install.sh
+++ b/files/config_make_install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+./configure
+make
+make install

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  strategy: free
   tasks:
     - name: "Include compile_gcc"
       include_role:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,8 @@
 ---
 - name: Converge
   hosts: all
-  strategy: free
+  vars:
+    test_gcc: true
   tasks:
     - name: "Include compile_gcc"
       include_role:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,3 +18,5 @@ provisioner:
   name: ansible
 verifier:
   name: ansible
+  config_options:
+    stdout_callback: yaml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
   name: galaxy
+  requirements_file: requirements.yml
 driver:
   name: docker
 lint: |

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: https://github.com/dockpack/base_gcc.git
+  name: base_gcc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
     url: "{{ gcc_url }}"
     dest: "/tmp/compile_gcc/gcc-{{ GCCVER }}.tar.gz"
     mode: 0755
-    validate_certs: false
+    validate_certs: "{{ gcc_mirror_url_signed }}"
   register: download_gcc_src
   until: download_gcc_src is succeeded
   delay: 3
@@ -56,11 +56,42 @@
 
 - name: unarchive GCC source
   unarchive:
-    src: "{{ download_gcc_src.dest }}"
+    src: "/tmp/compile_gcc/gcc-{{ GCCVER }}.tar.gz"
     dest: "{{ prefix }}/src"
     mode: u=rwX,g=rX,o=rX
     creates: "{{ prefix }}/src/gcc-{{ GCCVER }}"
     copy: false
+
+- name: download GCC dependencies
+  get_url:
+    url: "{{ dependencies_url }}{{ item.file }}"
+    checksum: "md5:{{ item.md5 }}"
+    dest: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.file }}"
+    validate_certs: "{{ dependencies_url_signed }}"
+  loop: "{{ dependencies }}"
+  loop_control:
+    label: "{{ dependencies_url }}{{ item.file }}"
+
+- name: unarchive GCC dependencies
+  unarchive:
+    src: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.file }}"
+    dest: "{{ prefix }}/src/gcc-{{ GCCVER }}/"
+    mode: u=rwX,g=rX,o=rX
+    creates: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.dir }}"
+    copy: false
+  loop: "{{ dependencies }}"
+  loop_control:
+    label: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.dir }}"
+
+- name: symlink GCC dependencies
+  file:
+    src: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.dir }}"
+    path: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.name }}"
+    state: link
+    mode: 0777
+  loop: "{{ dependencies }}"
+  loop_control:
+    label: "{{ prefix }}/src/gcc-{{ GCCVER }}/{{ item.name }}"
 
 - name: source devtoolset enable file
   when: collections_enabled and ansible_os_family == 'RedHat'
@@ -93,16 +124,6 @@
   args:
     chdir: "{{ prefix }}/src/binutils-{{ binutilsver }}"
     creates: "{{ prefix }}/bin/strip"
-
-- name: download_prerequisites
-  command: contrib/download_prerequisites
-  register: download_prerequisites
-  until: download_prerequisites.rc|int == 0
-  delay: 2
-  retries: 10
-  args:
-    chdir: "{{ prefix }}/src/gcc-{{ GCCVER }}"
-    creates: "{{ prefix }}/src/gcc-{{ GCCVER }}/isl-0.14.tar.bz2"
 
 - name: create directory
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: unpack Binutils source
   unarchive:
-    src: "{{ download_binutils.dest }}"
+    src: "/tmp/compile_gcc/binutils-{{ binutilsver }}.tar.bz2"
     dest: "{{ prefix }}/src"
     mode: u=rwX,g=rX,o=rX
     creates: "{{ prefix }}/src/binutils-{{ binutilsver }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -153,7 +153,7 @@
   script: config_make_install.sh
   args:
     chdir: "{{ prefix }}/src/dejagnu-{{ dejagnu_ver }}"
-    creates:  "{{ prefix }}/bin/dejagnu"
+    creates: "{{ prefix }}/bin/dejagnu"
   tags:
     - test
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,8 @@
   until: network_access is success
   delay: 2
   retries: 10
+  tags:
+    - test
 
 - name: create download directory
   file:
@@ -143,19 +145,23 @@
     dest: "{{ prefix }}/src"
     mode: u=rwX,g=rX,o=rX
     creates: "{{ prefix }}/src/dejagnu-{{ dejagnu_ver }}"
+  tags:
+    - test
 
 - name: install dejagnu
   when: test_gcc|bool
   script: config_make_install.sh
   args:
     chdir: "{{ prefix }}/src/dejagnu-{{ dejagnu_ver }}"
+    creates:  "{{ prefix }}/bin/dejagnu"
+  tags:
+    - test
 
 - name: create directory
   file:
     path: "{{ prefix }}/src/build"
     state: directory
     mode: 0755
-  changed_when: true
 
 - name: configure GCC source
   shell: "{{ cmd_env | default('') }} ../gcc-{{ GCCVER }}/configure \
@@ -164,7 +170,6 @@
     executable: /bin/bash
     chdir: "{{ prefix }}/src/build"
     creates: "{{ prefix }}/src/build/config.status"
-  changed_when: true
   tags:
     - skip_ansible_lint
 
@@ -174,9 +179,16 @@
     executable: /bin/bash
     chdir: "{{ prefix }}/src/build"
     creates: "{{ prefix }}/src/build/gcc/libgcc_s.so.1"
-  changed_when: true
   tags:
     - skip_ansible_lint
+
+- name: test GCC C++ compiler
+  when: test_gcc|bool
+  command: make -j {{ ansible_processor_vcpus }} check-c++
+  args:
+    chdir: "{{ prefix }}/src/build"
+  tags:
+    - test
 
 - name: install GCC with cxxabi.h as evidence
   command: "make -j {{ ansible_processor_vcpus }} install"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
         ansible_distribution == 'Red Hat Enterprise Linux' or
         ansible_distribution == 'RedHat'
 
-- name: install RPMs
+- name: install rpms_for_compiling_gcc
   yum:
     name: "{{ rpms_for_compiling_gcc }}"
     state: present
@@ -16,7 +16,17 @@
   delay: 2
   retries: 10
 
-- name: create directory
+- name: install rpms_for_testing_gcc
+  when: test_gcc|bool
+  yum:
+    name: "{{ rpms_for_testing_gcc }}"
+    state: present
+  register: network_access
+  until: network_access is success
+  delay: 2
+  retries: 10
+
+- name: create download directory
   file:
     path: /tmp/compile_gcc
     state: directory
@@ -119,11 +129,26 @@
   tags:
     - skip_ansible_lint
 
-- name: install binutils
+- name: install Binutils
   command: make install
   args:
     chdir: "{{ prefix }}/src/binutils-{{ binutilsver }}"
     creates: "{{ prefix }}/bin/strip"
+
+- name: unpack dejagnu source
+  when: test_gcc|bool
+  unarchive:
+    src: "{{ dejagnu_url }}"
+    remote_src: true
+    dest: "{{ prefix }}/src"
+    mode: u=rwX,g=rX,o=rX
+    creates: "{{ prefix }}/src/dejagnu-{{ dejagnu_ver }}"
+
+- name: install dejagnu
+  when: test_gcc|bool
+  script: config_make_install.sh
+  args:
+    chdir: "{{ prefix }}/src/dejagnu-{{ dejagnu_ver }}"
 
 - name: create directory
   file:

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -4,6 +4,9 @@ DTSVER: 7
 cplusplus_devtoolset: "devtoolset-{{ DTSVER }}"
 binutilsver: 2.29.1
 rpms_for_compiling_gcc:
+  - dejagnu
+  - expect
+  - tcl
   - flex
   - svn
   - texinfo-tex

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -3,10 +3,11 @@ collections_enabled: true
 DTSVER: 7
 cplusplus_devtoolset: "devtoolset-{{ DTSVER }}"
 binutilsver: 2.29.1
-rpms_for_compiling_gcc:
+rpms_for_testing_gcc:
   - dejagnu
   - expect
   - tcl
+rpms_for_compiling_gcc:
   - flex
   - svn
   - texinfo-tex

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -4,6 +4,9 @@ DTSVER: 10
 cplusplus_devtoolset: "devtoolset-{{ DTSVER }}"
 binutilsver: 2.29.1
 rpms_for_compiling_gcc:
+  - expect
+  - tcl
+  - python3-test
   - flex
   - svn
   - texinfo-tex

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -3,10 +3,11 @@ collections_enabled: true
 DTSVER: 10
 cplusplus_devtoolset: "devtoolset-{{ DTSVER }}"
 binutilsver: 2.29.1
-rpms_for_compiling_gcc:
+rpms_for_testing_gcc:
   - expect
   - tcl
   - python3-test
+rpms_for_compiling_gcc:
   - flex
   - svn
   - texinfo-tex

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -2,6 +2,9 @@
 collections_enabled: false
 binutilsver: 2.36.1
 rpms_for_compiling_gcc:
+  - expect
+  - tcl
+  - python3-test
   - flex
   - svn
   #  - texinfo-tex

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,10 +1,11 @@
 ---
 collections_enabled: false
 binutilsver: 2.36.1
-rpms_for_compiling_gcc:
+rpms_for_testing_gcc:
   - expect
   - tcl
   - python3-test
+rpms_for_compiling_gcc:
   - flex
   - svn
   #  - texinfo-tex


### PR DESCRIPTION
The script download_prerequisites needs internet, this PR should make on-premise use possible by changing group_vars to override defaults.

```yaml
gcc_mirror_url: 'http://mirrors.concertpass.com/gcc/releases'
gcc_mirror_url_signed: false
gnu_mirror: 'https://ftp.nluug.nl/pub/gnu/'
```